### PR TITLE
Fixed broken ga dashboard

### DIFF
--- a/dbt/macros/utils/hashmap_google_analytics_production_hostnames.sql
+++ b/dbt/macros/utils/hashmap_google_analytics_production_hostnames.sql
@@ -1,10 +1,10 @@
 {% macro hashmap_google_analytics_production_hostnames() %}
   (
     'hashmapinc.com', 
-    'profiler.snowflakeinspector.com', 
     'recommender.hashmapinc.com', 
     'snowflakeinspector.hashmapinc.com',
-    'estimator.hashmapinc.com',
-    'healthcheck.hashmapinc.com'
+    'estimator.snowflakeinspector.com',
+    'healthcheck.snowflakeinspector.com',
+    'profiler.snowflakeinspector.com'
   )
 {% endmacro %}

--- a/dbt/models/google_analytics/analytics/ga_hourly_traffic.sql
+++ b/dbt/models/google_analytics/analytics/ga_hourly_traffic.sql
@@ -24,7 +24,7 @@ SELECT
 
   -- Prepend hostname to page path when hostname is not the main hashmap site
   CASE 
-    WHEN TRAFFIC_HOSTNAME = 'www.hashmapinc.com' THEN TRAFFIC_PAGE_BASE_PATH
+    WHEN TRAFFIC_HOSTNAME = 'hashmapinc.com' THEN TRAFFIC_PAGE_BASE_PATH
     ELSE TRAFFIC_HOSTNAME || TRAFFIC_PAGE_BASE_PATH
   END AS TRAFFIC_PAGE
 

--- a/dbt/models/google_analytics/analytics/ga_hourly_traffic.sql
+++ b/dbt/models/google_analytics/analytics/ga_hourly_traffic.sql
@@ -1,13 +1,21 @@
+WITH TRAFFIC AS (
+  SELECT
+    TRAFFIC_TIME_CT,
+    REPLACE(TRAFFIC_HOSTNAME, 'www.', '') AS TRAFFIC_HOSTNAME,
+    TRAFFIC_CAMPAIGN,
+    REPLACE(TRAFFIC_PAGE_PATH, 'datarebels', 'hashmap') AS TRAFFIC_PAGE_PATH_RAW,
+    TRAFFIC_SOURCE_MEDIUM,
+    TRAFFIC_TOTAL_USERS_CNT,
+    TRAFFIC_NEW_USERS_CNT,
+    TRAFFIC_PAGEVIEWS_CNT,
+    TRAFFIC_SESSION_DURATION_AVG
+  
+  FROM
+    {{ ref('stg_ga_hourly_traffic') }}
+)
+
 SELECT
-  TRAFFIC_TIME_CT,
-  REPLACE(TRAFFIC_HOSTNAME, 'www.', '') AS TRAFFIC_HOSTNAME,
-  TRAFFIC_CAMPAIGN,
-  REPLACE(TRAFFIC_PAGE_PATH, 'datarebels', 'hashmap') AS TRAFFIC_PAGE_PATH_RAW,
-  TRAFFIC_SOURCE_MEDIUM,
-  TRAFFIC_TOTAL_USERS_CNT,
-  TRAFFIC_NEW_USERS_CNT,
-  TRAFFIC_PAGEVIEWS_CNT,
-  TRAFFIC_SESSION_DURATION_AVG,
+  *,
 
   -- clean traffic metadata
   SPLIT_PART(TRAFFIC_PAGE_PATH_RAW, '?', 1)     AS TRAFFIC_PAGE_BASE_PATH,
@@ -16,12 +24,12 @@ SELECT
 
   -- Prepend hostname to page path when hostname is not the main hashmap site
   CASE 
-      WHEN TRAFFIC_HOSTNAME = 'www.hashmapinc.com' THEN TRAFFIC_PAGE_BASE_PATH
-      ELSE TRAFFIC_HOSTNAME || TRAFFIC_PAGE_BASE_PATH
+    WHEN TRAFFIC_HOSTNAME = 'www.hashmapinc.com' THEN TRAFFIC_PAGE_BASE_PATH
+    ELSE TRAFFIC_HOSTNAME || TRAFFIC_PAGE_BASE_PATH
   END AS TRAFFIC_PAGE
 
 FROM
-  {{ ref('stg_ga_hourly_traffic') }}
+  TRAFFIC
 
 WHERE 
   -- only include traffic from production hostnames - this excludes `localhost`, `0.0.0.0`, etc...

--- a/dbt/tests/google_analytics/assert_all_production_hostnames_exist__ga_hourly_traffic.sql
+++ b/dbt/tests/google_analytics/assert_all_production_hostnames_exist__ga_hourly_traffic.sql
@@ -1,0 +1,11 @@
+SELECT
+  COUNT(DISTINCT TRAFFIC_HOSTNAME) NUMBER_OF_UNIQUE_HOSTNAMES
+
+FROM
+  {{ ref('ga_hourly_traffic') }}
+
+HAVING 
+  -- Check the hashmap_google_analytics_production_hostnames macro to find the correct number here.
+  -- at the time of writing this test, the number is 6
+  NUMBER_OF_UNIQUE_HOSTNAMES != 6
+  


### PR DESCRIPTION
### This PR includes:
- Fix to the google analytics production hostnames macro to use the correct URLs for the latest marketing accelerators
- addition of a test to ensure all expected production URLs make it into the ga_hourly_traffic model. Previously, we only checked for bad URLs and didn't double-check that ALL expected good URLs existed.
- fixed the ga_hourly_traffic model to use a CTE that removes an ambiguous predicate on the TRAFFIC_HOSTNAME column.
- update to traffic page calculations based on cleaning the `www.` out of the hostname in the CTE